### PR TITLE
add support for video backend

### DIFF
--- a/recipe/0101-find-ffmpeg-in-conda-env.patch
+++ b/recipe/0101-find-ffmpeg-in-conda-env.patch
@@ -7,7 +7,7 @@ index 85a6921..ede9662 100644
          )
  
 -    ffmpeg_exe = distutils.spawn.find_executable('ffmpeg')
-+    ffmpeg_exe = distutils.spawn.find_executable('ffmpeg', path=os.path.join(os.getenv('CONDA_PREFIX'), 'bin'))
++    ffmpeg_exe = distutils.spawn.find_executable('ffmpeg', path=os.path.join(os.getenv('PREFIX'), 'bin'))
      has_ffmpeg = ffmpeg_exe is not None
  
      if has_ffmpeg:

--- a/recipe/0101-find-ffmpeg-in-conda-env.patch
+++ b/recipe/0101-find-ffmpeg-in-conda-env.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 85a6921..ede9662 100644
+--- a/setup.py
++++ b/setup.py
+@@ -171,7 +171,7 @@ def get_extensions():
+             )
+         )
+ 
+-    ffmpeg_exe = distutils.spawn.find_executable('ffmpeg')
++    ffmpeg_exe = distutils.spawn.find_executable('ffmpeg', path=os.path.join(os.getenv('CONDA_PREFIX'), 'bin'))
+     has_ffmpeg = ffmpeg_exe is not None
+ 
+     if has_ffmpeg:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - _pytorch_select  {{ pytorch_select_version }}
     - pytorch-base     {{ pytorch }}
     - setuptools {{ setuptools }}
+    - ffmpeg {{ ffmpeg }}
+    - av
 
   run:
     - cudatoolkit {{ cudatoolkit }}     # [build_type == 'cuda']
@@ -35,6 +37,8 @@ requirements:
     - _pytorch_select  {{ pytorch_select_version }}
     - pytorch-base     {{ pytorch }}
     - six {{ six }}
+    - ffmpeg                            # versioning handled by run_exports
+    - av
 
 about:
   home: http://pytorch.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fa0a6f44a50451115d1499b3f2aa597e0092a07afce1068750260fa7dd2c85cb
 
 build:
-  number: 2 
+  number: 2
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   detect_binary_files_with_prefix: False
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fa0a6f44a50451115d1499b3f2aa597e0092a07afce1068750260fa7dd2c85cb
 
 build:
-  number: 1
+  number: 2 
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   detect_binary_files_with_prefix: False
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
   fn: torchvision-{{ version }}.tar.gz
   url: https://github.com/pytorch/vision/archive/v{{ version }}.tar.gz
   sha256: fa0a6f44a50451115d1499b3f2aa597e0092a07afce1068750260fa7dd2c85cb
+  patches:
+    - 0101-find-ffmpeg-in-conda-env.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - pytorch-base     {{ pytorch }}
     - setuptools {{ setuptools }}
     - ffmpeg {{ ffmpeg }}
-    - av
+    - av {{ av }}
 
   run:
     - cudatoolkit {{ cudatoolkit }}     # [build_type == 'cuda']
@@ -40,7 +40,7 @@ requirements:
     - pytorch-base     {{ pytorch }}
     - six {{ six }}
     - ffmpeg                            # versioning handled by run_exports
-    - av
+    - av                                # versioning handled by run_exports
 
 about:
   home: http://pytorch.org/


### PR DESCRIPTION
https://github.com/open-ce/open-ce/issues/25

requires - 
https://github.com/open-ce/av-feedstock/pull/1
https://github.com/open-ce/open-ce/pull/69

Fixes:
Torchvision issue reported in https://github.com/open-ce/open-ce/issues/36 (As now torchvision will not use system `ffmpeg`)