### PR TITLE
Remove the output section from meta-package recipe

### DIFF
--- a/variants/meta.yaml
+++ b/variants/meta.yaml
@@ -3,23 +3,21 @@
 {% set version = "0.8.2" %}
 
 package:
-   name: torchvision
-   version: {{ version }} 
+  name: torchvision{{ '-cpu' if build_type == 'cpu' else '' }}
+  version: {{ version }} 
 
-outputs:
-    - name: torchvision{{ '-cpu' if build_type == 'cpu' else '' }}
-      build:
-          number: 3
-          string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
-          string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
+build:
+  number: 4
+  string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
+  string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 
-      requirements:
-          run:
-             - pytorch-base {{ pytorch }}
-             - _pytorch_select {{ pytorch_select_version }}
-             - torchvision-base {{ torchvision }}
-             - python {{ python }}
-             - cudatoolkit {{ cudatoolkit }} #[build_type == 'cuda']
+requirements:
+  run:
+    - pytorch-base {{ pytorch }}
+    - _pytorch_select {{ pytorch_select_version }}
+    - torchvision-base {{ torchvision }}
+    - python {{ python }}
+    - cudatoolkit {{ cudatoolkit }} #[build_type == 'cuda']
 
 about:
   home: http://pytorch.org/


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Removes the output section from the meta-package recipe. This was causing an error with conda_build.api.render and wasn't needed since there was only a single output.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
